### PR TITLE
Fix/br1 email link

### DIFF
--- a/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeek.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeek.java
@@ -1,5 +1,6 @@
 package edu.tcu.cs.projectpulse.activeweek;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.tcu.cs.projectpulse.section.Section;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -34,6 +35,7 @@ public class ActiveWeek {
     @Column(nullable = false)
     private boolean active = true;
 
+    @JsonIgnore
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "section_id", nullable = false)

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/email/EmailService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/email/EmailService.java
@@ -32,8 +32,13 @@ public class EmailService {
     public void sendStudentInvitation(String toEmail, String adminName, String adminEmail,
                                       String token, String customMessage) {
         String registrationLink = baseUrl + "/register?token=" + token;
-        String body = (customMessage != null && !customMessage.isBlank()) ? customMessage
-                : buildDefaultInvitationBody(adminName, adminEmail, registrationLink);
+        String body;
+        if (customMessage != null && !customMessage.isBlank()) {
+            // Always append the registration link so the recipient can actually register
+            body = customMessage + "\n\nTo complete your registration, use this link:\n" + registrationLink;
+        } else {
+            body = buildDefaultInvitationBody(adminName, adminEmail, registrationLink);
+        }
 
         send(toEmail,
                 "Welcome to The Peer Evaluation Tool - Complete Your Registration",

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/report/ReportService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/report/ReportService.java
@@ -51,7 +51,7 @@ public class ReportService {
         // All students in this section
         List<AppUser> students = userRepository.findByRole(UserRole.STUDENT).stream()
                 .filter(u -> u.getSection() != null && u.getSection().getId().equals(sectionId))
-                .sorted(Comparator.comparing(AppUser::getLastName))
+                .sorted(Comparator.comparing(AppUser::getLastName, Comparator.nullsFirst(Comparator.naturalOrder())))
                 .toList();
 
         // All submitted evals for this week (entire section)
@@ -92,7 +92,7 @@ public class ReportService {
                 .orElseThrow(() -> new ObjectNotFoundException("ActiveWeek", weekId));
 
         List<AppUser> students = team.getStudents().stream()
-                .sorted(Comparator.comparing(AppUser::getLastName))
+                .sorted(Comparator.comparing(AppUser::getLastName, Comparator.nullsFirst(Comparator.naturalOrder())))
                 .toList();
 
         Set<Long> submitterIds = new HashSet<>();

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/team/TeamService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/team/TeamService.java
@@ -135,10 +135,14 @@ public class TeamService {
     public void removeInstructor(Long teamId, Long instructorId) {
         Team team = getTeamOrThrow(teamId);
         AppUser instructor = getUserOrThrow(instructorId);
-        boolean removed = team.getInstructors().remove(instructor);
-        if (!removed) {
+        if (!team.getInstructors().contains(instructor)) {
             throw new IllegalArgumentException("Instructor is not assigned to this team.");
         }
+        // BR-1: team must retain at least one instructor
+        if (team.getInstructors().size() <= 1) {
+            throw new IllegalStateException("Cannot remove the last instructor from a team. Assign another instructor first.");
+        }
+        team.getInstructors().remove(instructor);
         teamRepository.save(team);
         emailService.sendTeamRemoval(instructor.getEmail(), instructor.getFirstName(), team.getName());
     }

--- a/backend/src/test/java/edu/tcu/cs/projectpulse/team/TeamServiceTest.java
+++ b/backend/src/test/java/edu/tcu/cs/projectpulse/team/TeamServiceTest.java
@@ -181,4 +181,36 @@ class TeamServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("not a student");
     }
+
+    // ── removeInstructor (BR-1) ───────────────────────────────────────────────
+
+    @Test
+    void removeInstructor_givenLastInstructor_throwsIllegalStateException() {
+        AppUser instructor = new AppUser();
+        instructor.setId(20L);
+        instructor.setRole(UserRole.INSTRUCTOR);
+        team.getInstructors().add(instructor);
+
+        given(teamRepository.findById(1L)).willReturn(Optional.of(team));
+        given(userRepository.findById(20L)).willReturn(Optional.of(instructor));
+
+        assertThatThrownBy(() -> teamService.removeInstructor(1L, 20L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("last instructor");
+    }
+
+    @Test
+    void removeInstructor_givenMultipleInstructors_removesSuccessfully() {
+        AppUser inst1 = new AppUser(); inst1.setId(20L); inst1.setRole(UserRole.INSTRUCTOR);
+        AppUser inst2 = new AppUser(); inst2.setId(21L); inst2.setRole(UserRole.INSTRUCTOR);
+        team.getInstructors().add(inst1);
+        team.getInstructors().add(inst2);
+
+        given(teamRepository.findById(1L)).willReturn(Optional.of(team));
+        given(userRepository.findById(20L)).willReturn(Optional.of(inst1));
+
+        teamService.removeInstructor(1L, 20L);
+
+        then(teamRepository).should().save(team);
+    }
 }


### PR DESCRIPTION
Title: fix: Generate Weeks 500 error, report NPE on null last name
                                                                                                                                                              
  Summary                                                   

  - Generate Weeks crash (500) — ActiveWeekController returns raw JPA entities and spring.jpa.open-in-view=false closes the Hibernate session before Jackson serializes the
   response. Accessing the lazy section field threw LazyInitializationException → "An unexpected error occurred." Fixed with @JsonIgnore on ActiveWeek.section.
  - WAR/Peer report crash (500) — Sorting students by last name with Comparator.comparing(AppUser::getLastName) throws NullPointerException if any student's last name is  
  null. Switched to Comparator.nullsFirst in both report methods.                                                                                                          
   
  Test plan                                                                                                                                                                
                                                            
  - ./mvnw test — 121 tests, 0 failures
  - Frontend lint and type-check clean