### PR TITLE
fix: active week save collision and invite dialog feedback reset

### DIFF
--- a/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekRepository.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekRepository.java
@@ -15,4 +15,6 @@ public interface ActiveWeekRepository extends JpaRepository<ActiveWeek, Long> {
     List<ActiveWeek> findBySectionIdAndActiveTrue(Long sectionId);
 
     Optional<ActiveWeek> findBySectionIdAndWeekStart(Long sectionId, LocalDate weekStart);
+
+    void deleteBySectionId(Long sectionId);
 }

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekService.java
@@ -37,9 +37,10 @@ public class ActiveWeekService {
     public List<ActiveWeek> setupWeeks(Long sectionId, ActiveWeekSetupRequest request) {
         Section section = sectionService.getSectionOrThrow(sectionId);
 
-        // Remove existing weeks first
-        activeWeekRepository.deleteAll(
-                activeWeekRepository.findBySectionIdOrderByWeekStartAsc(sectionId));
+        // Remove existing weeks first and flush so unique(section_id, week_start)
+        // won't conflict with immediately re-inserted rows in the same transaction.
+        activeWeekRepository.deleteBySectionId(sectionId);
+        activeWeekRepository.flush();
 
         Set<LocalDate> inactives = request.inactiveWeekStarts();
         List<ActiveWeek> weeks = new ArrayList<>();

--- a/backend/src/test/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekServiceTest.java
+++ b/backend/src/test/java/edu/tcu/cs/projectpulse/activeweek/ActiveWeekServiceTest.java
@@ -58,7 +58,6 @@ class ActiveWeekServiceTest {
     @Test
     void setupWeeks_generatesWeeksForSectionRange() {
         given(sectionService.getSectionOrThrow(1L)).willReturn(section);
-        given(activeWeekRepository.findBySectionIdOrderByWeekStartAsc(1L)).willReturn(List.of());
         given(activeWeekRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
 
         List<ActiveWeek> result = activeWeekService.setupWeeks(1L,
@@ -72,7 +71,6 @@ class ActiveWeekServiceTest {
     @Test
     void setupWeeks_marksSpecifiedWeeksInactive() {
         given(sectionService.getSectionOrThrow(1L)).willReturn(section);
-        given(activeWeekRepository.findBySectionIdOrderByWeekStartAsc(1L)).willReturn(List.of());
         given(activeWeekRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
 
         LocalDate inactive = LocalDate.of(2024, 9, 9);
@@ -88,15 +86,13 @@ class ActiveWeekServiceTest {
 
     @Test
     void setupWeeks_deletesExistingWeeksBeforeRegeneration() {
-        ActiveWeek existing = new ActiveWeek();
-        existing.setId(99L);
         given(sectionService.getSectionOrThrow(1L)).willReturn(section);
-        given(activeWeekRepository.findBySectionIdOrderByWeekStartAsc(1L)).willReturn(List.of(existing));
         given(activeWeekRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
 
         activeWeekService.setupWeeks(1L, new ActiveWeekSetupRequest(Collections.emptySet()));
 
-        then(activeWeekRepository).should().deleteAll(List.of(existing));
+        then(activeWeekRepository).should().deleteBySectionId(1L);
+        then(activeWeekRepository).should().flush();
     }
 
     @Test

--- a/frontend/src/views/InstructorListView.vue
+++ b/frontend/src/views/InstructorListView.vue
@@ -2,7 +2,7 @@
   <v-container class="pa-6" fluid>
     <div class="d-flex align-center mb-6 ga-3">
       <h1 class="text-h5 font-weight-bold flex-grow-1">Instructors</h1>
-      <v-btn color="primary" prepend-icon="mdi-email-plus" @click="inviteDialog = true">
+      <v-btn color="primary" prepend-icon="mdi-email-plus" @click="openInviteDialog">
         Invite Instructors
       </v-btn>
     </div>
@@ -131,7 +131,7 @@
         </v-card-text>
         <v-card-actions class="px-4 pb-4">
           <v-spacer />
-          <v-btn variant="text" @click="inviteDialog = false">Cancel</v-btn>
+          <v-btn variant="text" @click="closeInviteDialog">Cancel</v-btn>
           <v-btn color="primary" :loading="inviting" @click="sendInvites">Send Invitations</v-btn>
         </v-card-actions>
       </v-card>
@@ -140,7 +140,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue'
+  import { onMounted, ref, watch } from 'vue'
   import { api, type User } from '@/api'
 
   const instructors = ref<User[]>([])
@@ -154,6 +154,21 @@
   const inviteError = ref('')
   const inviteSuccess = ref('')
   const invite = ref({ emails: '', customMessage: '' })
+
+  function clearInviteFeedback () {
+    inviteError.value = ''
+    inviteSuccess.value = ''
+  }
+
+  function openInviteDialog () {
+    clearInviteFeedback()
+    inviteDialog.value = true
+  }
+
+  function closeInviteDialog () {
+    inviteDialog.value = false
+    clearInviteFeedback()
+  }
 
   async function load () {
     loading.value = true
@@ -197,8 +212,7 @@
   }
 
   async function sendInvites () {
-    inviteError.value = ''
-    inviteSuccess.value = ''
+    clearInviteFeedback()
     if (!invite.value.emails.trim()) {
       inviteError.value = 'At least one email is required.'
       return
@@ -214,6 +228,10 @@
       inviting.value = false
     }
   }
+
+  watch(inviteDialog, isOpen => {
+    if (!isOpen) clearInviteFeedback()
+  })
 
   onMounted(load)
 </script>

--- a/frontend/src/views/StudentListView.vue
+++ b/frontend/src/views/StudentListView.vue
@@ -6,7 +6,7 @@
         v-if="auth.role === 'ADMIN'"
         color="primary"
         prepend-icon="mdi-email-plus"
-        @click="inviteDialog = true"
+        @click="openInviteDialog"
       >
         Invite Students
       </v-btn>
@@ -139,7 +139,7 @@
         </v-card-text>
         <v-card-actions class="px-4 pb-4">
           <v-spacer />
-          <v-btn variant="text" @click="inviteDialog = false">Cancel</v-btn>
+          <v-btn variant="text" @click="closeInviteDialog">Cancel</v-btn>
           <v-btn color="primary" :loading="inviting" @click="sendInvites">Send Invitations</v-btn>
         </v-card-actions>
       </v-card>
@@ -161,7 +161,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue'
+  import { onMounted, ref, watch } from 'vue'
   import { api, type User } from '@/api'
   import { useAuthStore } from '@/stores/auth'
 
@@ -183,6 +183,21 @@
   const deleting = ref(false)
   const studentToDelete = ref<User | null>(null)
 
+  function clearInviteFeedback () {
+    inviteError.value = ''
+    inviteSuccess.value = ''
+  }
+
+  function openInviteDialog () {
+    clearInviteFeedback()
+    inviteDialog.value = true
+  }
+
+  function closeInviteDialog () {
+    inviteDialog.value = false
+    clearInviteFeedback()
+  }
+
   async function load () {
     loading.value = true
     error.value = ''
@@ -201,8 +216,7 @@
   }
 
   async function sendInvites () {
-    inviteError.value = ''
-    inviteSuccess.value = ''
+    clearInviteFeedback()
     if (!invite.value.sectionId || !invite.value.emails.trim()) {
       inviteError.value = 'Section and at least one email are required.'
       return
@@ -221,6 +235,10 @@
       inviting.value = false
     }
   }
+
+  watch(inviteDialog, isOpen => {
+    if (!isOpen) clearInviteFeedback()
+  })
 
   function confirmDelete (student: User) {
     studentToDelete.value = student


### PR DESCRIPTION
## Summary
- Fix Active Week Setup save failures caused by unique-key collisions when re-saving week configuration.
- Reset invite success/error banners when the student/instructor invite dialogs are closed and reopened.
- Keep all other behavior unchanged (no section view-button changes in this PR).

## What Changed
- ActiveWeekService.setupWeeks(...)
  - Replaced delete-by-entity-list with deleteBySectionId(sectionId) followed by lush() before re-insert.
- ActiveWeekRepository
  - Added deleteBySectionId(Long sectionId).
- StudentListView.vue and InstructorListView.vue
  - Added explicit invite feedback reset on dialog open/close.
  - Wired cancel/open actions to clear stale messages.

## Validation
- Backend tests: ./mvnw test passed (121 tests).
- Frontend checks: 
pm run type-check and 
pm run lint passed.
- Manual QA:
  - Active Week save no longer errors when toggling active/inactive and saving.
  - Invite success/error messages no longer persist after closing/reopening invite dialogs.