### PR TITLE
Fix: restrict private peer comments to instructors

### DIFF
--- a/backend/src/main/java/edu/tcu/cs/projectpulse/report/ReportService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/report/ReportService.java
@@ -18,6 +18,8 @@ import edu.tcu.cs.projectpulse.war.WARActivity;
 import edu.tcu.cs.projectpulse.war.WARActivityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +49,7 @@ public class ReportService {
                 .orElseThrow(() -> new ObjectNotFoundException("Section", sectionId));
         ActiveWeek week = weekRepository.findById(weekId)
                 .orElseThrow(() -> new ObjectNotFoundException("ActiveWeek", weekId));
+        boolean includePrivateComments = includePrivateCommentsForCurrentUser();
 
         // All students in this section
         List<AppUser> students = userRepository.findByRole(UserRole.STUDENT).stream()
@@ -71,7 +74,7 @@ public class ReportService {
 
         // Build per-student summary (as evaluatee)
         List<StudentPeerSummary> summaries = students.stream()
-                .map(student -> buildStudentSummary(student, allEvals))
+                .map(student -> buildStudentSummary(student, allEvals, includePrivateComments))
                 .toList();
 
         return new SectionPeerReportResponse(
@@ -134,6 +137,7 @@ public class ReportService {
     public StudentPeerRangeResponse studentPeerReport(Long studentId, LocalDate start, LocalDate end) {
         AppUser student = userRepository.findById(studentId)
                 .orElseThrow(() -> new ObjectNotFoundException("User", studentId));
+        boolean includePrivateComments = includePrivateCommentsForCurrentUser();
 
         List<PeerEvaluation> evals = evalRepository.findByEvaluateeId(studentId).stream()
                 .filter(PeerEvaluation::isSubmitted)
@@ -154,7 +158,7 @@ public class ReportService {
                     List<PeerEvaluation> weekEvals = entry.getValue();
                     BigDecimal grade = computeGrade(weekEvals);
                     List<StudentPeerSummary.EvaluatorDetail> details = weekEvals.stream()
-                            .map(this::toEvaluatorDetail)
+                            .map(e -> toEvaluatorDetail(e, includePrivateComments))
                             .toList();
                     return new StudentPeerRangeResponse.WeekEntry(
                             week.getId(), week.getWeekStart().toString(), grade, details);
@@ -210,7 +214,8 @@ public class ReportService {
 
     // ── private helpers ───────────────────────────────────────────────────────
 
-    private StudentPeerSummary buildStudentSummary(AppUser student, List<PeerEvaluation> allEvals) {
+    private StudentPeerSummary buildStudentSummary(AppUser student, List<PeerEvaluation> allEvals,
+                                                   boolean includePrivateComments) {
         List<PeerEvaluation> received = allEvals.stream()
                 .filter(e -> e.getEvaluatee().getId().equals(student.getId()))
                 .toList();
@@ -219,7 +224,7 @@ public class ReportService {
         boolean submitted = !received.isEmpty();
 
         List<StudentPeerSummary.EvaluatorDetail> details = received.stream()
-                .map(this::toEvaluatorDetail)
+                .map(e -> toEvaluatorDetail(e, includePrivateComments))
                 .toList();
 
         return new StudentPeerSummary(
@@ -229,7 +234,7 @@ public class ReportService {
         );
     }
 
-    private StudentPeerSummary.EvaluatorDetail toEvaluatorDetail(PeerEvaluation e) {
+    private StudentPeerSummary.EvaluatorDetail toEvaluatorDetail(PeerEvaluation e, boolean includePrivateComments) {
         List<StudentPeerSummary.ScoreDetail> scores = e.getScores().stream()
                 .map(s -> new StudentPeerSummary.ScoreDetail(s.getCriterion().getName(), s.getScore()))
                 .toList();
@@ -238,8 +243,17 @@ public class ReportService {
                 e.getEvaluator().getFirstName() + " " + e.getEvaluator().getLastName(),
                 scores,
                 e.getPublicComments(),
-                e.getPrivateComments()
+                includePrivateComments ? e.getPrivateComments() : null
         );
+    }
+
+    private boolean includePrivateCommentsForCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return false;
+        }
+        return authentication.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_INSTRUCTOR".equals(a.getAuthority()));
     }
 
     /** Grade = average of per-evaluator totals (UC-29/31/33 algorithm). */

--- a/backend/src/test/java/edu/tcu/cs/projectpulse/report/ReportServiceTest.java
+++ b/backend/src/test/java/edu/tcu/cs/projectpulse/report/ReportServiceTest.java
@@ -20,12 +20,16 @@ import edu.tcu.cs.projectpulse.user.UserRepository;
 import edu.tcu.cs.projectpulse.user.UserRole;
 import edu.tcu.cs.projectpulse.war.WARActivity;
 import edu.tcu.cs.projectpulse.war.WARActivityRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -55,6 +59,8 @@ class ReportServiceTest {
 
     @BeforeEach
     void setUp() {
+        setAuthenticatedRole("INSTRUCTOR");
+
         section = new Section();
         section.setId(1L);
         section.setName("2024-2025");
@@ -88,6 +94,11 @@ class ReportServiceTest {
         team.setInstructors(new ArrayList<>());
     }
 
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
     // ── sectionPeerReport (UC-31) ─────────────────────────────────────────────
 
     @Test
@@ -119,6 +130,46 @@ class ReportServiceTest {
 
         // bob submitted (is evaluator), alice did not
         assertThat(result.nonSubmitters()).containsExactly("Alice Smith");
+    }
+
+    @Test
+    void sectionPeerReport_givenInstructor_includesPrivateComments() {
+        setAuthenticatedRole("INSTRUCTOR");
+        PeerEvaluation eval = submittedEval(bob, alice, week, 8);
+
+        given(sectionRepository.findById(1L)).willReturn(Optional.of(section));
+        given(weekRepository.findById(10L)).willReturn(Optional.of(week));
+        given(userRepository.findByRole(UserRole.STUDENT)).willReturn(List.of(alice, bob));
+        given(evalRepository.findByWeekId(10L)).willReturn(List.of(eval));
+
+        SectionPeerReportResponse result = reportService.sectionPeerReport(1L, 10L);
+        var aliceSummary = result.students().stream()
+                .filter(s -> s.studentId().equals(alice.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(aliceSummary.evaluations().get(0).privateComments())
+                .isEqualTo("Private note");
+    }
+
+    @Test
+    void sectionPeerReport_givenAdmin_redactsPrivateComments() {
+        setAuthenticatedRole("ADMIN");
+        PeerEvaluation eval = submittedEval(bob, alice, week, 8);
+
+        given(sectionRepository.findById(1L)).willReturn(Optional.of(section));
+        given(weekRepository.findById(10L)).willReturn(Optional.of(week));
+        given(userRepository.findByRole(UserRole.STUDENT)).willReturn(List.of(alice, bob));
+        given(evalRepository.findByWeekId(10L)).willReturn(List.of(eval));
+
+        SectionPeerReportResponse result = reportService.sectionPeerReport(1L, 10L);
+        var aliceSummary = result.students().stream()
+                .filter(s -> s.studentId().equals(alice.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(aliceSummary.evaluations().get(0).privateComments())
+                .isNull();
     }
 
     @Test
@@ -293,5 +344,14 @@ class ReportServiceTest {
         a.setPlannedHours(4.0);
         a.setActualHours(3.5);
         return a;
+    }
+
+    private void setAuthenticatedRole(String role) {
+        var auth = new UsernamePasswordAuthenticationToken(
+                "test@tcu.edu",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_" + role))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 }

--- a/frontend/src/views/SectionPeerReportView.vue
+++ b/frontend/src/views/SectionPeerReportView.vue
@@ -114,7 +114,7 @@
                     {{ score.criterionName }}
                   </th>
                   <th>Public Comment</th>
-                  <th>Private Comment</th>
+                  <th v-if="showPrivateComments">Private Comment</th>
                 </tr>
               </thead>
               <tbody>
@@ -127,7 +127,7 @@
                     {{ score.score }}
                   </td>
                   <td>{{ ev.publicComments ?? '—' }}</td>
-                  <td>{{ ev.privateComments ?? '—' }}</td>
+                  <td v-if="showPrivateComments">{{ ev.privateComments ?? '—' }}</td>
                 </tr>
               </tbody>
             </v-table>
@@ -147,8 +147,9 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue'
+  import { computed, onMounted, ref } from 'vue'
   import { api, type Section, type SectionPeerReport } from '@/api'
+  import { useAuthStore } from '@/stores/auth'
 
   interface WeekOption {
     id: number
@@ -166,6 +167,8 @@
   const loadingWeeks = ref(false)
   const loadingReport = ref(false)
   const error = ref('')
+  const auth = useAuthStore()
+  const showPrivateComments = computed(() => auth.role === 'INSTRUCTOR')
 
   onMounted(async () => {
     loadingSections.value = true

--- a/frontend/src/views/StudentDetailView.vue
+++ b/frontend/src/views/StudentDetailView.vue
@@ -133,7 +133,7 @@
                           {{ score.criterionName }}
                         </th>
                         <th>Public</th>
-                        <th>Private</th>
+                        <th v-if="showPrivateComments">Private</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -143,7 +143,7 @@
                           {{ score.score }}
                         </td>
                         <td>{{ ev.publicComments ?? '—' }}</td>
-                        <td>{{ ev.privateComments ?? '—' }}</td>
+                        <td v-if="showPrivateComments">{{ ev.privateComments ?? '—' }}</td>
                       </tr>
                     </tbody>
                   </v-table>
@@ -206,12 +206,15 @@
 </template>
 
 <script lang="ts" setup>
-  import { onMounted, ref } from 'vue'
+  import { computed, onMounted, ref } from 'vue'
   import { useRoute } from 'vue-router'
   import { api, type StudentPeerRangeReport, type StudentWARRangeReport, type User } from '@/api'
+  import { useAuthStore } from '@/stores/auth'
 
   const route = useRoute()
   const studentId = Number(route.params.id)
+  const auth = useAuthStore()
+  const showPrivateComments = computed(() => auth.role === 'INSTRUCTOR')
 
   const student = ref<User | null>(null)
   const peerReport = ref<StudentPeerRangeReport | null>(null)


### PR DESCRIPTION
## Summary
Fixes a privacy leak where private peer-evaluation comments were visible to admins in instructor report views.

### What changed
- Backend: made peer-report mapping role-aware so privateComments are only included for users with INSTRUCTOR role.
- Backend tests: added coverage to verify instructor sees private comments and admin gets them redacted (null).
- Frontend: hide private-comment columns for non-instructors in:
  - SectionPeerReportView.vue
  - StudentDetailView.vue

## Why
Private comments are labeled as instructor-only. Admin users should not see them in report tables.

## Validation
- backend: ./mvnw test (123 tests, 0 failures)
- frontend: npm run type-check
- frontend: npm run lint