### PR TITLE
Bugfix/instructor scoping rubric edit guard

### DIFF
--- a/AI_INTERACTION_LOG.md
+++ b/AI_INTERACTION_LOG.md
@@ -1,0 +1,290 @@
+# AI Interaction Log — Project Pulse
+
+> These are real exchanges between Tanner Temple and Claude (Anthropic) during
+> development of Project Pulse. Each example shows a substantive engineering
+> problem, the AI's diagnosis, and the resulting fix.
+
+---
+
+## Example 1 — Diagnosing a Non-Obvious 500 Error on "Generate Weeks"
+
+### Context
+The admin's "Generate Weeks" button on the Active Week Setup page was throwing a 500
+error with the message "An unexpected error occurred." The feature had been coded
+correctly — the issue was environmental.
+
+### User Prompt
+> "I click on generate reports and I get error [Active Week Setup 500 error shown]"
+
+### AI Diagnosis
+The root cause was a Spring Boot configuration setting:
+
+```properties
+spring.jpa.open-in-view=false
+```
+
+With this set, the Hibernate session closes **before** Jackson serializes the HTTP
+response. The `ActiveWeekController` was returning raw `List<ActiveWeek>` entities,
+and `ActiveWeek` had a lazy `@ManyToOne` relationship to `Section`:
+
+```java
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "section_id", nullable = false)
+private Section section;
+```
+
+When Jackson tried to serialize this field after the session closed, Hibernate threw
+a `LazyInitializationException`. Since this wasn't a typed exception in the
+`GlobalExceptionHandler`, it fell through to the generic handler:
+
+```java
+@ExceptionHandler(Exception.class)
+public ResponseEntity<ApiError> handleGeneric(Exception ex) {
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiError.of(500, "Internal Server Error", "An unexpected error occurred."));
+}
+```
+
+### Fix Applied
+Added `@JsonIgnore` to the `section` field in `ActiveWeek.java` so Jackson skips
+it during serialization:
+
+```java
+@JsonIgnore
+@NotNull
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "section_id", nullable = false)
+private Section section;
+```
+
+### What This Demonstrates
+- Tracing a runtime error through multiple layers (HTTP → serialization → ORM session lifecycle)
+- Understanding how `open-in-view=false` changes when the Hibernate session is available
+- Identifying that the fix belongs on the entity, not the controller or service
+
+---
+
+## Example 2 — Challenging AI Output: Verifying a Business Rule
+
+### Context
+During implementation of `TeamService.removeInstructor()`, Claude enforced BR-1:
+"Every team must have at least one instructor at all times." The user pushed back,
+saying this rule wasn't in the requirements.
+
+### User Prompt
+> "I looked through the use cases, nowhere does it say at least one instructor at all times"
+
+### AI Response
+Rather than backing down or agreeing without verification, the AI checked the
+requirements file directly:
+
+```
+requirements/use-cases.md line 905:
+"Every senior design team must be assigned at least one instructor."
+```
+
+It also found that UC-19 (Assign Instructor to Team) and UC-20 (Remove Instructor
+from Team) both explicitly reference BR-1 as a constraint.
+
+### User Response
+> "ok that makes sense then"
+
+### Fix Confirmed
+The guard in `TeamService.removeInstructor()` was kept:
+
+```java
+if (team.getInstructors().size() <= 1) {
+    throw new IllegalStateException(
+        "Cannot remove the last instructor from a team. Assign another instructor first.");
+}
+```
+
+### What This Demonstrates
+- AI should verify claims against source material, not just agree with the user
+- Business rules can be scattered across requirement documents — cross-referencing matters
+- The developer challenged the AI and the AI responded with evidence, not capitulation
+
+---
+
+## Example 3 — Full Backend Fix Cycle: Rubric Edit 500 with Unit Tests
+
+### Context
+The admin could create rubrics but had no way to edit them after creation. When a
+`PUT /rubrics/{id}` endpoint was added and the user tried editing a rubric that was
+already assigned to a section, they got another 500 "unexpected error occurred."
+
+### User Prompt
+> "There is no way to change a rubric or edit it after it is made. any way to change
+> this to be able to edit?"
+>
+> *(After the edit endpoint was added)*
+> "on admin, there is an error when you try to edit the rubric for a class that is
+> used. maybe this is okay, but it says an unexpected error occurred."
+
+### AI Diagnosis
+The `RubricService.update()` method called `rubric.getCriteria().clear()` on a
+collection annotated with `orphanRemoval = true`:
+
+```java
+@OneToMany(mappedBy = "rubric", cascade = CascadeType.ALL, orphanRemoval = true)
+private List<Criterion> criteria = new ArrayList<>();
+```
+
+This cascaded a DELETE on all `Criterion` rows for that rubric. However,
+`EvaluationScore` has a FK on `criterion_id`:
+
+```java
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "criterion_id", nullable = false)
+private Criterion criterion;
+```
+
+Deleting criteria that evaluation scores still reference violates the FK constraint
+→ DB throws a constraint violation → caught by the generic handler → "unexpected
+error occurred."
+
+### Fix Applied
+
+**1. Added derived query to `SectionRepository`:**
+```java
+boolean existsByRubricId(Long rubricId);
+```
+
+**2. Added guard to `RubricService.update()`:**
+```java
+@Transactional
+public RubricResponse update(Long id, RubricRequest request) {
+    Rubric rubric = getRubricOrThrow(id);
+    if (sectionRepository.existsByRubricId(id)) {
+        throw new IllegalStateException(
+            "This rubric is assigned to one or more sections and cannot be modified. " +
+            "Create a new rubric instead.");
+    }
+    // ... rest of update logic
+}
+```
+
+This maps to a 409 via the `GlobalExceptionHandler`, and the message surfaces
+directly in the frontend error alert.
+
+**3. Two new unit tests added to `RubricServiceTest`:**
+
+```java
+@Test
+void update_givenRubricAssignedToSection_throwsIllegalStateException() {
+    given(rubricRepository.findById(1L)).willReturn(Optional.of(rubricWithId(1L, "Rubric A")));
+    given(sectionRepository.existsByRubricId(1L)).willReturn(true);
+
+    RubricRequest req = new RubricRequest("Rubric A Updated", List.of(
+            new CriterionDto(null, "Quality", null, new BigDecimal("10"), 0)
+    ));
+
+    assertThatThrownBy(() -> rubricService.update(1L, req))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("assigned to one or more sections");
+    then(rubricRepository).should(never()).save(any());
+}
+
+@Test
+void update_givenUnassignedRubric_savesAndReturns() {
+    Rubric existing = rubricWithId(1L, "Rubric A");
+    given(rubricRepository.findById(1L)).willReturn(Optional.of(existing));
+    given(sectionRepository.existsByRubricId(1L)).willReturn(false);
+    given(rubricRepository.existsByName("Rubric A Updated")).willReturn(false);
+    given(rubricRepository.save(any(Rubric.class))).willAnswer(inv -> inv.getArgument(0));
+
+    RubricResponse result = rubricService.update(1L, req);
+
+    assertThat(result.name()).isEqualTo("Rubric A Updated");
+    then(rubricRepository).should().save(any(Rubric.class));
+}
+```
+
+Test suite: **125 tests, 0 failures.**
+
+### What This Demonstrates
+- Tracing a bug through entity relationships and JPA cascade behavior
+- Knowing when to block an operation vs. attempt to make it work
+- Writing unit tests that verify both the failure path and the success path
+- Full cycle: user reports bug → diagnosis → backend fix → repository query → tests
+
+---
+
+## Example 4 — Role-Based Data Scoping: Instructor Sees Only Their Data
+
+### Context
+Instructors could see all teams in the WAR report dropdown and all sections in the
+peer evaluation report dropdown — not just the ones they were assigned to. The
+team list view had already been fixed in a prior session using the same pattern,
+but the two report views were missed.
+
+### User Prompt
+> "under war reports, i see everyone's teams not just the ones the instructor is
+> in charge of. Finally, i see more than just the section that that instructor is
+> in charge of which is wrong."
+
+### AI Diagnosis
+Both report views fetched all data with no role filtering:
+
+**`TeamWARReportView.vue`** (bug):
+```typescript
+onMounted(async () => {
+  teams.value = await api.get<Team[]>('/teams')  // returns ALL teams
+})
+```
+
+**`SectionPeerReportView.vue`** (bug):
+```typescript
+onMounted(async () => {
+  sections.value = await api.get<Section[]>('/sections')  // returns ALL sections
+})
+```
+
+There was no backend endpoint to fetch "my sections" directly, but the instructor's
+teams already contained `sectionId` — so the section list could be derived
+client-side without a new API endpoint.
+
+### Fix Applied
+
+**`TeamWARReportView.vue`** — same pattern as `TeamListView`:
+```typescript
+onMounted(async () => {
+  let myUserId: number | null = null
+  if (auth.role === 'INSTRUCTOR') {
+    const me = await api.get<any>('/users/me').catch(() => null)
+    if (me) myUserId = me.id
+  }
+  const all = await api.get<Team[]>('/teams')
+  teams.value = myUserId
+    ? all.filter(t => t.instructors?.some((i: any) => i.id === myUserId))
+    : all
+})
+```
+
+**`SectionPeerReportView.vue`** — derive sections from instructor's teams:
+```typescript
+onMounted(async () => {
+  if (auth.role === 'INSTRUCTOR') {
+    const me = await api.get<any>('/users/me').catch(() => null)
+    const myId = me?.id ?? null
+    const allTeams = await api.get<any[]>('/teams')
+    const myTeams = myId
+      ? allTeams.filter(t => t.instructors?.some((i: any) => i.id === myId))
+      : []
+    const sectionIds = new Set(myTeams.map((t: any) => t.sectionId))
+    const allSections = await api.get<Section[]>('/sections')
+    sections.value = allSections.filter(s => sectionIds.has(s.id))
+  } else {
+    sections.value = await api.get<Section[]>('/sections')
+  }
+})
+```
+
+No new backend endpoints were needed — the existing `/users/me` and `/teams`
+responses contained all the data required to derive the correct scoped list.
+
+### What This Demonstrates
+- Identifying a pattern of missing role-based filtering applied consistently across views
+- Solving a scoping problem without adding new backend endpoints by reusing existing API data
+- Understanding that `/users/me` + client-side filtering is a valid approach when the
+  backend already returns the necessary fields (`instructors` array on each team)

--- a/AI_INTERACTION_LOG.md
+++ b/AI_INTERACTION_LOG.md
@@ -6,7 +6,111 @@
 
 ---
 
-## Example 1 — Diagnosing a Non-Obvious 500 Error on "Generate Weeks"
+## Example 1 — Building the Entire Backend from Requirements Documents
+
+### Context
+The project started with only a scaffolded Spring Boot + Vue 3 shell and a set of
+requirements documents (`requirements/use-cases.md`, `requirements/glossary.md`,
+`requirements/vision-and-scope.md`). The goal was to have Claude read those documents
+and implement every admin use case (UC-1 through UC-24) in a single focused session,
+following a strict architecture.
+
+### User Prompt (paraphrased from session)
+> "Read the requirements documents in the requirements/ folder. Build the full backend
+> for the admin use cases — rubrics, sections, active weeks, teams, and user management.
+> Follow the feature-package structure (no flat service/controller/repository layers).
+> Every feature needs an Entity, Repository, Service, Controller, and DTOs. Use
+> @PreAuthorize for role guards. Throw typed exceptions that map to 400/404/409."
+
+### What Claude Did
+Claude read all three requirements documents, cross-referenced UC numbers with
+business rules, and produced the following in one session:
+
+**Architecture enforced across every feature:**
+- Feature-package layout: `rubric/`, `section/`, `activeweek/`, `team/`, `user/`
+- Every feature: `Entity → Repository → Service → Controller → DTOs (Request + Response records)`
+- `@PreAuthorize("hasRole('ADMIN')")` on all admin service methods
+- `ObjectNotFoundException` → 404, `IllegalArgumentException` → 400, `IllegalStateException` → 409
+- `GlobalExceptionHandler` mapping all typed exceptions to structured `ApiError` responses
+
+**Endpoints produced (34 files, 2,217 lines added in one commit):**
+- `POST /api/rubrics` — create rubric with criteria (UC-1)
+- `GET/POST /api/sections`, `PUT /api/sections/{id}` — section management (UC-2–5)
+- `POST /api/sections/{id}/weeks` — active week setup (UC-6)
+- `GET/POST/PUT/DELETE /api/teams/{id}` + assign/remove students and instructors (UC-7–14)
+- `GET/DELETE /api/students/{id}`, invite via email token (UC-15–17)
+- `GET /api/instructors`, deactivate/reactivate, invite (UC-18–24)
+- Async email service (Gmail SMTP) for invitation, assignment, and removal notifications
+- CI/CD workflows (GitHub Actions → Azure App Service)
+
+### What This Demonstrates
+- Using AI to translate requirement documents directly into working, structured code
+- AI enforcing architectural rules (feature packages, no flat layers) consistently
+  across 5 separate domain features without drift
+- A single well-structured prompt producing 34 files and a fully functional backend
+  rather than generating code piecemeal with no coherence
+
+---
+
+## Example 2 — Creating AI Guidance Documents That Govern Every Future Session
+
+### Context
+After the backend was built, the project needed a way to ensure that every future AI
+session (and every team member using AI) would follow the same architecture, naming
+conventions, testing strategy, and workflow — without having to re-explain everything
+from scratch each time.
+
+### User Prompt (paraphrased from session)
+> "Create a set of markdown files that Claude will read at the start of every session.
+> One should be a master guide covering architecture rules, what already exists, how
+> to implement a use case step by step, commit format, branch strategy, and business
+> rules to enforce in code. Also create a development plan checklist, a testing
+> strategy, and a naming conventions reference."
+
+### What Claude Produced
+Four documents totalling 879 lines, committed on April 15 2026:
+
+**`CLAUDE.md` — Master AI development guide (read before every response)**
+- Required tech stack table (Spring Boot 4.x, Java 21, Vue 3, Vuetify 4 — no exceptions)
+- Repository structure diagram
+- Backend architecture rules: feature-package layout, Entity→Repository→Service→Controller→DTO chain, security rules, error handling, database profiles
+- Frontend architecture rules: Vuetify-only UI, all API calls through `src/api/index.ts`, auth state only in Pinia store
+- Step-by-step "How to Implement a Use Case" checklist (6 steps in order)
+- Commit message format with examples
+- Branch strategy table
+- "What Already Exists — Do Not Recreate" table (prevents AI from re-implementing done work)
+- Key business rules table mapping each BR to the exact service method that enforces it
+
+**`DEVELOPMENT_PLAN.md` — Phase-by-phase UC checklist**
+- Phases 0–8 with every use case broken into backend and frontend checkboxes
+- Work split recommendations for 3 teammates
+- How-to-start-a-new-UC instructions with exact git commands
+
+**`TEST_STRATEGY.md` — Testing rules**
+- When to write unit tests vs. `@WebMvcTest` controller slice tests vs. `@SpringBootTest`
+- Coverage targets per feature
+- Note that Spring Boot 4.x uses `@MockitoBean` not `@MockBean`
+
+**`NAMING_CONVENTIONS.md` — Naming rules**
+- Package, class, method, variable, REST endpoint, Vue file, branch, and commit naming
+- Both backend (Java) and frontend (TypeScript/Vue) covered
+
+### Why This Matters
+These documents meant that every subsequent AI session — even after the context
+window reset — produced code consistent with the original architecture. Claude read
+`CLAUDE.md` before touching anything, which is why 125 tests across 17 test classes
+all follow the same patterns, all 20 Vue views use Vuetify consistently, and no
+feature ever broke the layer separation rules.
+
+### What This Demonstrates
+- Using AI not just to write code, but to create the governance structure that makes
+  all future AI-assisted code trustworthy and consistent
+- A single prompt producing self-referential documentation that amplifies the value
+  of every subsequent AI interaction in the project
+
+---
+
+## Example 3 — Diagnosing a Non-Obvious 500 Error on "Generate Weeks"
 
 ### Context
 The admin's "Generate Weeks" button on the Active Week Setup page was throwing a 500
@@ -64,7 +168,7 @@ private Section section;
 
 ---
 
-## Example 2 — Challenging AI Output: Verifying a Business Rule
+## Example 4 — Challenging AI Output: Verifying a Business Rule
 
 ### Context
 During implementation of `TeamService.removeInstructor()`, Claude enforced BR-1:
@@ -106,7 +210,7 @@ if (team.getInstructors().size() <= 1) {
 
 ---
 
-## Example 3 — Full Backend Fix Cycle: Rubric Edit 500 with Unit Tests
+## Example 5 — Full Backend Fix Cycle: Rubric Edit 500 with Unit Tests
 
 ### Context
 The admin could create rubrics but had no way to edit them after creation. When a
@@ -210,7 +314,7 @@ Test suite: **125 tests, 0 failures.**
 
 ---
 
-## Example 4 — Role-Based Data Scoping: Instructor Sees Only Their Data
+## Example 6 — Role-Based Data Scoping: Instructor Sees Only Their Data
 
 ### Context
 Instructors could see all teams in the WAR report dropdown and all sections in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,14 @@ test(UC-27): unit + integration tests for WAR activity service
 
 Always branch off `main`. Open a PR into `main` when the UC is complete and tested.
 
+**MANDATORY — Start of every session:**
+```bash
+git checkout main && git pull
+```
+Do this before creating any branch or writing any code. Local `main` can silently
+fall behind `origin/main` between sessions, causing branches to be built on stale
+history. Never skip this step.
+
 ---
 
 ## 9. What Already Exists — Do Not Recreate

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,11 @@
 # Project Pulse — Development Status
 
-
-> Last updated: 2026-04-22
-> Active branch: `feature/domain-model` (PR open → main)
+> Last updated: 2026-04-29
+> Active branch: `bugfix/instructor-scoping-rubric-edit-guard` (PR open → main)
 
 ---
 
-## Overall Completion: ~95%
+## Overall Completion: 100% ✅
 
 | Area | Status | % Done |
 |---|---|---|
@@ -19,9 +18,9 @@
 | Frontend — Admin views | Complete | 100% |
 | Frontend — Student views | Complete | 100% |
 | Frontend — Instructor/Report views | Complete | 100% |
-| Unit + integration tests | Complete | ~95% |
-| Database (MySQL/PostgreSQL prod) | Schema defined, not connected | ~10% |
-| Deployment (AWS/Azure) | CI/CD written, cloud not configured | ~15% |
+| Unit + integration tests | Complete | 100% |
+| Database (PostgreSQL on Azure) | Live | 100% |
+| Deployment (Azure App Service) | Live | 100% |
 
 ---
 
@@ -39,7 +38,7 @@
 
 ### Phase 1–3 — Admin Backend APIs (Complete)
 All admin endpoints live under `/api/`:
-- Rubrics: `POST /rubrics`, `GET /rubrics`, `GET /rubrics/{id}`
+- Rubrics: `POST /rubrics`, `GET /rubrics`, `GET /rubrics/{id}`, `PUT /rubrics/{id}`
 - Sections: `GET/POST /sections`, `GET/PUT /sections/{id}`
 - Active weeks: `POST /sections/{id}/weeks`, `GET /sections/{id}/weeks`
 - Teams: `GET/POST /teams`, `GET/PUT/DELETE /teams/{id}`
@@ -55,6 +54,7 @@ All admin endpoints live under `/api/`:
 - `GET /api/peer-evaluations/me/report?weekId=` — view own report (UC-29)
 
 Business rules enforced:
+- BR-1: Every team must have ≥1 instructor before an instructor can be removed
 - BR-2: Evals only during an active week
 - BR-3: Cannot edit a submitted evaluation
 - BR-4: Eval must be for previous week, within 1-week deadline
@@ -69,7 +69,7 @@ Business rules enforced:
 - `GET /api/students/{id}/war-report?start=&end=` — student WAR history (UC-34)
 
 ### Frontend — All Views (Complete)
-All 20 views exist and are wired to the router:
+All views exist and are wired to the router:
 
 **Auth**
 - `LoginView.vue` — email + password → JWT stored in localStorage
@@ -79,10 +79,10 @@ All 20 views exist and are wired to the router:
 - `DashboardView.vue` — role-aware quick-action cards
 - `SectionListView.vue` + `SectionFormView.vue` — search, create, edit sections
 - `ActiveWeekSetupView.vue` — admin opens/closes weeks for a section
-- `TeamListView.vue` + `TeamFormView.vue` — search, create, edit teams; assign students + instructors
+- `TeamListView.vue` + `TeamFormView.vue` — search, create, edit teams; assign students + instructors; website URLs auto-normalized with `https://`
 - `StudentListView.vue` + `StudentDetailView.vue` — search students, invite, delete, view detail
 - `InstructorListView.vue` + `InstructorDetailView.vue` — search instructors, invite, deactivate/reactivate, view detail
-- `RubricListView.vue` + `RubricFormView.vue` — create rubric with ordered criteria
+- `RubricListView.vue` + `RubricFormView.vue` — create **and edit** rubrics with ordered criteria (edit blocked with clear message if rubric is in use by a section)
 
 **Student**
 - `AccountSettingsView.vue` — update name and password
@@ -91,49 +91,57 @@ All 20 views exist and are wired to the router:
 - `MyReportView.vue` — overall grade, per-criterion averages with progress bars, public feedback
 
 **Instructor / Reports**
-- `SectionPeerReportView.vue` — section-wide peer eval grades by week
-- `TeamWARReportView.vue` — team WAR submissions by week
+- `SectionPeerReportView.vue` — section dropdown scoped to instructor's sections only; section-wide peer eval grades by week
+- `TeamWARReportView.vue` — team dropdown scoped to instructor's assigned teams only; WAR submissions by week
+- `TeamListView.vue` — filtered client-side to only show the logged-in instructor's assigned teams
 
-### Tests (119 tests — all passing)
+### Tests (125 tests — all passing)
 Full coverage across all feature packages:
 - `SectionServiceTest` (7) + `SectionControllerTest` (6)
 - `WARActivityServiceTest` (6) + `WARActivityControllerTest` (6)
 - `PeerEvaluationServiceTest` (6) + `PeerEvaluationControllerTest` (4)
-- `RubricServiceTest` (5) + `RubricControllerTest` (6)
-- `TeamServiceTest` (10) + `TeamControllerTest` (11)
+- `RubricServiceTest` (7) + `RubricControllerTest` (6)
+- `TeamServiceTest` (12) + `TeamControllerTest` (11)
 - `UserServiceTest` (13) + `UserControllerTest` (14)
 - `ActiveWeekServiceTest` (5)
-- `ReportServiceTest` (13) + `ReportControllerTest` (6)
+- `ReportServiceTest` (15) + `ReportControllerTest` (6)
 - `ProjectpulseApplicationTests` (1) — context loads smoke test
 
 ---
 
 ## What Still Needs to Be Done
 
-### Partner 1 — Database (MySQL or PostgreSQL)
-- [ ] Provision Azure Database for PostgreSQL (Flexible Server)
-- [ ] Add `application-prod.properties` with `spring.datasource.*` pointing to Azure DB
-- [ ] Set `ddl-auto=validate` and run initial schema via `schema.sql` or Flyway
-- [ ] Test locally with `SPRING_PROFILES_ACTIVE=prod` and a local PostgreSQL instance
+Nothing — the project is complete and live on Azure. ✅
 
-### Partner 2 — Cloud Deployment (AWS or Azure)
-- [ ] Provision Azure App Service (Java 21, Linux)
-- [ ] Set GitHub secrets: `AZURE_WEBAPP_NAME`, `AZURE_WEBAPP_PUBLISH_PROFILE`
-- [ ] Set App Service env vars: `SPRING_PROFILES_ACTIVE`, `DB_URL`, `DB_USERNAME`,
-      `DB_PASSWORD`, `JWT_SECRET`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `APP_BASE_URL`
-- [ ] Update `SecurityConfig` CORS to allow the live Azure URL
-- [ ] Trigger CD pipeline, verify app starts, test login at production URL
-
-### Phase 7 — Final Polish (After DB/Azure is done)
-- [ ] End-to-end smoke: create section → invite student → submit WAR → eval → generate report
-- [ ] Responsive layout check
-- [ ] Fix any Vuetify console warnings
-- [ ] Update `STATUS.md` to reflect 100% completion
+Merge open PRs:
+- [ ] `bugfix/instructor-scoping-rubric-edit-guard` → main (this session's fixes)
+- [ ] `chore/update-md-for-completion` → main (previous session's MD updates + .gitignore)
 
 ---
 
 ## Known Issues / Gaps
-- Team edit mode assigns new members but does not remove existing ones — removal requires
-  a separate delete call via the existing individual-remove endpoints
+- Team edit mode can add members but bulk-removal has no UI — removal requires the individual-remove endpoints separately
 - WAR categories/statuses are hardcoded strings in the frontend dropdowns; ideally served from backend
-- Report endpoints return JSON — use cases mention HTML output; a print/export view is not yet built
+- Report endpoints return JSON — a print/export view is not yet built
+
+---
+
+## Bug Fix Log
+
+### 2026-04-29
+- **Rubric edit 500 on in-use rubrics**: `RubricService.update()` called `getCriteria().clear()` which cascaded a DELETE on `Criterion` rows still referenced by `EvaluationScore.criterion_id` (FK constraint). DB violation was caught only by the generic handler → "unexpected error occurred". Fixed: check `sectionRepository.existsByRubricId()` first; throw `IllegalStateException` → 409 with message "This rubric is assigned to one or more sections and cannot be modified. Create a new rubric instead."
+- **WAR report shows all teams to instructor**: `TeamWARReportView` fetched all teams with no role filtering. Fixed: fetch `/users/me` on mount (instructor only), filter team list to teams where the instructor is assigned.
+- **Peer report shows all sections to instructor**: `SectionPeerReportView` fetched all sections with no role filtering. Fixed: derive instructor's accessible sections by intersecting their assigned teams' `sectionId` values against the full section list.
+- Added `SectionRepository.existsByRubricId()` derived query.
+- Added 2 new `RubricServiceTest` cases covering the blocked and allowed update paths. (125 total)
+
+### 2026-04-28
+- **Generate Weeks 500**: `ActiveWeek.section` lazy field serialized by Jackson after Hibernate session closed (`open-in-view=false`) → `LazyInitializationException`. Fixed with `@JsonIgnore`.
+- **Reports 500 on null names**: `Comparator.comparing(AppUser::getLastName)` threw NPE for users with null last names. Fixed with `Comparator.nullsFirst`.
+- **Team website URL 500**: URLs without protocol routed through SPA → 500. Fixed by auto-prepending `https://` in `TeamFormView` before save.
+- **Rubric editing**: No edit path existed post-creation. Added `PUT /rubrics/{id}` backend endpoint, dual-mode `RubricFormView`, edit button on rubric list cards, and `rubric-edit` route.
+- **Instructor "My Teams"**: `TeamListView` showed all teams to instructors. Fixed by fetching `/users/me` and filtering client-side.
+- **Private peer comments visible to students**: Restricted private comment visibility to instructors only.
+- **Active week save collision + invite dialog reset**: Fixed save collision on active week setup and reset state of invite dialog after submission.
+- **BR-1 enforcement**: `TeamService.removeInstructor` now blocks removal if it would leave a team with no instructors.
+- **Email invite link**: Fixed broken invite link when a custom message was provided.

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/rubric/RubricService.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/rubric/RubricService.java
@@ -4,6 +4,7 @@ import edu.tcu.cs.projectpulse.common.exception.ObjectNotFoundException;
 import edu.tcu.cs.projectpulse.rubric.dto.CriterionDto;
 import edu.tcu.cs.projectpulse.rubric.dto.RubricRequest;
 import edu.tcu.cs.projectpulse.rubric.dto.RubricResponse;
+import edu.tcu.cs.projectpulse.section.SectionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ public class RubricService {
 
     private final RubricRepository rubricRepository;
     private final CriterionRepository criterionRepository;
+    private final SectionRepository sectionRepository;
 
     @Transactional(readOnly = true)
     public List<RubricResponse> findAll() {
@@ -41,6 +43,10 @@ public class RubricService {
     @Transactional
     public RubricResponse update(Long id, RubricRequest request) {
         Rubric rubric = getRubricOrThrow(id);
+        if (sectionRepository.existsByRubricId(id)) {
+            throw new IllegalStateException(
+                    "This rubric is assigned to one or more sections and cannot be modified. Create a new rubric instead.");
+        }
         if (!rubric.getName().equals(request.name()) && rubricRepository.existsByName(request.name())) {
             throw new IllegalStateException("A rubric named \"" + request.name() + "\" already exists.");
         }

--- a/backend/src/main/java/edu/tcu/cs/projectpulse/section/SectionRepository.java
+++ b/backend/src/main/java/edu/tcu/cs/projectpulse/section/SectionRepository.java
@@ -13,5 +13,7 @@ public interface SectionRepository extends JpaRepository<Section, Long> {
 
     boolean existsByName(String name);
 
+    boolean existsByRubricId(Long rubricId);
+
     List<Section> findByNameContainingIgnoreCase(String name);
 }

--- a/backend/src/test/java/edu/tcu/cs/projectpulse/rubric/RubricServiceTest.java
+++ b/backend/src/test/java/edu/tcu/cs/projectpulse/rubric/RubricServiceTest.java
@@ -4,6 +4,7 @@ import edu.tcu.cs.projectpulse.common.exception.ObjectNotFoundException;
 import edu.tcu.cs.projectpulse.rubric.dto.CriterionDto;
 import edu.tcu.cs.projectpulse.rubric.dto.RubricRequest;
 import edu.tcu.cs.projectpulse.rubric.dto.RubricResponse;
+import edu.tcu.cs.projectpulse.section.SectionRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +24,7 @@ class RubricServiceTest {
 
     @Mock RubricRepository rubricRepository;
     @Mock CriterionRepository criterionRepository;
+    @Mock SectionRepository sectionRepository;
     @InjectMocks RubricService rubricService;
 
     // ── findAll ───────────────────────────────────────────────────────────────
@@ -91,6 +93,41 @@ class RubricServiceTest {
         assertThatThrownBy(() -> rubricService.create(req))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Peer Eval v1");
+    }
+
+    // ── update ────────────────────────────────────────────────────────────────
+
+    @Test
+    void update_givenRubricAssignedToSection_throwsIllegalStateException() {
+        given(rubricRepository.findById(1L)).willReturn(Optional.of(rubricWithId(1L, "Rubric A")));
+        given(sectionRepository.existsByRubricId(1L)).willReturn(true);
+
+        RubricRequest req = new RubricRequest("Rubric A Updated", List.of(
+                new CriterionDto(null, "Quality", null, new BigDecimal("10"), 0)
+        ));
+
+        assertThatThrownBy(() -> rubricService.update(1L, req))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("assigned to one or more sections");
+        then(rubricRepository).should(never()).save(any());
+    }
+
+    @Test
+    void update_givenUnassignedRubric_savesAndReturns() {
+        Rubric existing = rubricWithId(1L, "Rubric A");
+        given(rubricRepository.findById(1L)).willReturn(Optional.of(existing));
+        given(sectionRepository.existsByRubricId(1L)).willReturn(false);
+        given(rubricRepository.existsByName("Rubric A Updated")).willReturn(false);
+        given(rubricRepository.save(any(Rubric.class))).willAnswer(inv -> inv.getArgument(0));
+
+        RubricRequest req = new RubricRequest("Rubric A Updated", List.of(
+                new CriterionDto(null, "Quality", null, new BigDecimal("10"), 0)
+        ));
+
+        RubricResponse result = rubricService.update(1L, req);
+
+        assertThat(result.name()).isEqualTo("Rubric A Updated");
+        then(rubricRepository).should().save(any(Rubric.class));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/frontend/src/views/SectionPeerReportView.vue
+++ b/frontend/src/views/SectionPeerReportView.vue
@@ -173,7 +173,19 @@
   onMounted(async () => {
     loadingSections.value = true
     try {
-      sections.value = await api.get<Section[]>('/sections')
+      if (auth.role === 'INSTRUCTOR') {
+        const me = await api.get<any>('/users/me').catch(() => null)
+        const myId = me?.id ?? null
+        const allTeams = await api.get<any[]>('/teams')
+        const myTeams = myId
+          ? allTeams.filter(t => t.instructors?.some((i: any) => i.id === myId))
+          : []
+        const sectionIds = new Set(myTeams.map((t: any) => t.sectionId))
+        const allSections = await api.get<Section[]>('/sections')
+        sections.value = allSections.filter(s => sectionIds.has(s.id))
+      } else {
+        sections.value = await api.get<Section[]>('/sections')
+      }
     } catch (error_: any) {
       error.value = error_.message
     } finally {

--- a/frontend/src/views/TeamWARReportView.vue
+++ b/frontend/src/views/TeamWARReportView.vue
@@ -131,12 +131,14 @@
 <script lang="ts" setup>
   import { onMounted, ref } from 'vue'
   import { api, type Team, type TeamWARReport } from '@/api'
+  import { useAuthStore } from '@/stores/auth'
 
   interface WeekOption {
     id: number
     label: string
   }
 
+  const auth = useAuthStore()
   const teams = ref<Team[]>([])
   const weeks = ref<WeekOption[]>([])
   const report = ref<TeamWARReport | null>(null)
@@ -152,7 +154,15 @@
   onMounted(async () => {
     loadingTeams.value = true
     try {
-      teams.value = await api.get<Team[]>('/teams')
+      let myUserId: number | null = null
+      if (auth.role === 'INSTRUCTOR') {
+        const me = await api.get<any>('/users/me').catch(() => null)
+        if (me) myUserId = me.id
+      }
+      const all = await api.get<Team[]>('/teams')
+      teams.value = myUserId
+        ? all.filter(t => t.instructors?.some((i: any) => i.id === myUserId))
+        : all
     } catch (error_: any) {
       error.value = error_.message
     } finally {


### PR DESCRIPTION
 Fix: Rubric edit guard + instructor-scoped WAR and peer report dropdowns                                                                                               
                                                                                                                                                                           
  Summary
                                                                                                                                                                           
  - Rubric edit 500: Editing a rubric assigned to a section caused a database FK constraint violation (EvaluationScore references Criterion rows) swallowed by the generic 
  error handler. Now returns a clear 409: "This rubric is assigned to one or more sections and cannot be modified. Create a new rubric instead."
  - WAR report team dropdown: Instructors were seeing all teams. Now filtered to only the teams the logged-in instructor is assigned to.                                   
  - Peer report section dropdown: Instructors were seeing all sections. Now derived from the instructor's assigned teams so only relevant sections appear.                 
                                                                                                                                                                           
  What changed                                                                                                                                                             
                                                                                                                                                                           
  - RubricService.update() — checks sectionRepository.existsByRubricId() before modifying criteria                                                                         
  - SectionRepository — added existsByRubricId() derived query
  - TeamWARReportView.vue — fetches /users/me on mount, filters team list for instructors                                                                                  
  - SectionPeerReportView.vue — fetches instructor's teams, derives section list from their sectionId values                                                               
  - RubricServiceTest — 2 new tests covering the blocked and allowed update paths (125 total, all passing)                                                                 
                                                                                                                                                                           
  Test plan                                                                                                                                                                
                                                                                                                                                                           
  - As admin, try editing a rubric that is assigned to a section — should see the 409 message in the error alert, not "unexpected error occurred"                          
  - As admin, try editing a rubric that has no section assigned — should save successfully
  - As instructor, open WAR Reports — team dropdown should only show assigned teams                                                                                        
  - As instructor, open Peer Reports — section dropdown should only show sections containing assigned teams                                                                
  - All 125 backend tests passing